### PR TITLE
qca-nss-tunipip6 NSS firmware core dump fix for NSS-11.2-K5.15 branch.

### DIFF
--- a/qca-nss-clients/Makefile
+++ b/qca-nss-clients/Makefile
@@ -163,7 +163,7 @@ define KernelPackage/qca-nss-drv-tunipip6
   TITLE:=Kernel driver for NSS (connection manager) - DS-lite and ipip6 Tunnel
   DEPENDS:=+@NSS_DRV_TUNIPIP6_ENABLE +kmod-iptunnel6 +kmod-ip6-tunnel \
 		+PACKAGE_kmod-qca-nss-drv:kmod-qca-nss-drv
-  FILES:=$(PKG_BUILD_DIR)/tunipip6/qca-nss-tunipip6.ko
+  FILES:=$(PKG_BUILD_DIR)/qca-nss-tunipip6.ko
   AUTOLOAD:=$(call AutoLoad,60,qca-nss-tunipip6)
 endef
 

--- a/qca-nss-clients/patches/0007-revert-tunipip6-11.2.patch
+++ b/qca-nss-clients/patches/0007-revert-tunipip6-11.2.patch
@@ -1,0 +1,528 @@
+--- a/Makefile	2022-10-11 21:56:36.290000000 +0900
++++ b/Makefile	2022-10-11 21:59:11.130000000 +0900
+@@ -5,8 +5,10 @@ ccflags-y := -I$(obj) -I$(obj)/..
+ export BUILD_ID = \"Build Id: $(shell date +'%m/%d/%y, %H:%M:%S')\"
+ ccflags-y += -DNSS_CLIENT_BUILD_ID="$(BUILD_ID)"
+ 
++qca-nss-tunipip6-objs := nss_connmgr_tunipip6.o
+ qca-nss-tun6rd-objs := nss_connmgr_tun6rd.o
+ 
++ccflags-y += -DNSS_TUNIPIP6_DEBUG_LEVEL=0
+ ccflags-y += -DNSS_TUN6RD_DEBUG_LEVEL=0
+ ccflags-y += -Werror
+ 
+@@ -21,7 +23,7 @@ obj-$(map-t)+= map/map-t/
+ obj-$(portifmgr)+= portifmgr/
+ obj-$(pptp)+= pptp/
+ obj-$(profile)+= profiler/
+-obj-$(tunipip6)+= tunipip6/
++obj-$(tunipip6)+= qca-nss-tunipip6.o
+ obj-$(tun6rd)+= qca-nss-tun6rd.o
+ obj-$(qdisc)+= nss_qdisc/
+ obj-$(vlan-mgr)+= vlan/
+--- /dev/null	2022-10-04 19:54:04.170000000 +0900
++++ b/nss_connmgr_tunipip6.c	2022-10-11 21:54:01.000000000 +0900
+@@ -0,0 +1,503 @@
++/*
++ **************************************************************************
++ * Copyright (c) 2014, 2017-2018, The Linux Foundation. All rights reserved.
++ * Permission to use, copy, modify, and/or distribute this software for
++ * any purpose with or without fee is hereby granted, provided that the
++ * above copyright notice and this permission notice appear in all copies.
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
++ * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ **************************************************************************
++ */
++
++/*
++ * nss_tunipip6.c
++ *
++ * This file is the NSS DS-lit and IPP6  tunnel module
++ * ------------------------REVISION HISTORY-----------------------------
++ * Qualcomm Atheros	    15/sep/2013		     Created
++ */
++
++#include <linux/version.h>
++#include <linux/types.h>
++#include <linux/ip.h>
++#include <linux/of.h>
++#include <linux/tcp.h>
++#include <linux/module.h>
++#include <linux/skbuff.h>
++#include <net/ipv6.h>
++#if (LINUX_VERSION_CODE <= KERNEL_VERSION(3,9,0))
++#include <net/ipip.h>
++#else
++#include <net/ip_tunnels.h>
++#endif
++#include <net/ip6_tunnel.h>
++#include <linux/if_arp.h>
++#include <nss_api_if.h>
++
++/*
++ * NSS tunipip6 debug macros
++ */
++#if (NSS_TUNIPIP6_DEBUG_LEVEL < 1)
++#define nss_tunipip6_assert(fmt, args...)
++#else
++#define nss_tunipip6_assert(c) if (!(c)) { BUG_ON(!(c)); }
++#endif
++
++#if defined(CONFIG_DYNAMIC_DEBUG)
++
++/*
++ * Compile messages for dynamic enable/disable
++ */
++#define nss_tunipip6_warning(s, ...) pr_debug("%s[%d]:" s, __func__, __LINE__, ##__VA_ARGS__)
++#define nss_tunipip6_info(s, ...) pr_debug("%s[%d]:" s, __func__, __LINE__, ##__VA_ARGS__)
++#define nss_tunipip6_trace(s, ...) pr_debug("%s[%d]:" s, __func__, __LINE__, ##__VA_ARGS__)
++#else
++
++/*
++ * Statically compile messages at different levels
++ */
++#if (NSS_TUNIPIP6_DEBUG_LEVEL < 2)
++#define nss_tunipip6_warning(s, ...)
++#else
++#define nss_tunipip6_warning(s, ...) pr_warn("%s[%d]:" s, __func__, __LINE__, ##__VA_ARGS__)
++#endif
++
++#if (NSS_TUNIPIP6_DEBUG_LEVEL < 3)
++#define nss_tunipip6_info(s, ...)
++#else
++#define nss_tunipip6_info(s, ...)   pr_notice("%s[%d]:" s, __func__, __LINE__, ##__VA_ARGS__)
++#endif
++
++#if (NSS_TUNIPIP6_DEBUG_LEVEL < 4)
++#define nss_tunipip6_trace(s, ...)
++#else
++#define nss_tunipip6_trace(s, ...)  pr_info("%s[%d]:" s, __func__, __LINE__, ##__VA_ARGS__)
++#endif
++#endif
++
++/*
++ *  tunipip6 stats structure
++ */
++struct nss_tunipip6_stats {
++	uint32_t rx_packets;	/* Number of received packets */
++	uint32_t rx_bytes;	/* Number of received bytes */
++	uint32_t tx_packets;	/* Number of transmitted packets */
++	uint32_t tx_bytes;	/* Number of transmitted bytes */
++};
++
++/*
++ * nss_tunipip6_encap_exception()
++ *	Exception handler registered to NSS driver.
++ *
++ * This function is called when no rule is found for successful encapsulation.
++ */
++static void nss_tunipip6_encap_exception(struct net_device *dev, struct sk_buff *skb, __attribute__((unused)) struct napi_struct *napi)
++{
++	skb->dev = dev;
++	nss_tunipip6_info("received - %d bytes name %s ver %x\n",
++			skb->len, dev->name, (skb->data[0] >> 4));
++
++	skb->protocol = htons(ETH_P_IP);
++	skb_reset_network_header(skb);
++	skb->pkt_type = PACKET_HOST;
++	skb->skb_iif = dev->ifindex;
++	skb->ip_summed = CHECKSUM_NONE;
++	netif_receive_skb(skb);
++}
++
++/*
++ * nss_tunipip6_decap_exception()
++ *	Exception handler registered to NSS driver.
++ *
++ * This function is called when no rule is found for successful decapsulation.
++ */
++static void nss_tunipip6_decap_exception(struct net_device *dev, struct sk_buff *skb, __attribute__((unused)) struct napi_struct *napi)
++{
++	skb->dev = dev;
++	nss_tunipip6_info("received - %d bytes name %s ver %x\n",
++			skb->len, dev->name, (skb->data[0] >> 4));
++
++	skb->protocol = htons(ETH_P_IPV6);
++	skb_reset_network_header(skb);
++	skb->pkt_type = PACKET_HOST;
++	skb->skb_iif = dev->ifindex;
++	skb->ip_summed = CHECKSUM_NONE;
++	netif_receive_skb(skb);
++}
++
++/*
++ *  nss_tunipip6_update_dev_stats
++ *	Update the Dev stats received from NetAp
++ */
++static void nss_tunipip6_update_dev_stats(struct net_device *dev,
++					struct nss_tunipip6_stats_sync_msg *sync_stats)
++{
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
++	struct pcpu_sw_netstats stats;
++
++	u64_stats_init(&stats.syncp);
++	u64_stats_update_begin(&stats.syncp);
++	stats.rx_packets = sync_stats->node_stats.rx_packets;
++	stats.rx_bytes = sync_stats->node_stats.rx_bytes;
++	stats.tx_packets = sync_stats->node_stats.tx_packets;
++	stats.tx_bytes = sync_stats->node_stats.tx_bytes;
++	u64_stats_update_end(&stats.syncp);
++#else
++	struct nss_tunipip6_stats stats;
++
++	stats.rx_packets = sync_stats->node_stats.rx_packets;
++	stats.rx_bytes = sync_stats->node_stats.rx_bytes;
++	stats.tx_packets = sync_stats->node_stats.tx_packets;
++	stats.tx_bytes = sync_stats->node_stats.tx_bytes;
++#endif
++
++	dev->stats.rx_dropped += nss_cmn_rx_dropped_sum(&sync_stats->node_stats);
++	ip6_update_offload_stats(dev, (void *)&stats);
++
++}
++
++/*
++ * nss_tunipip6_event_receive()
++ *	Event Callback to receive events from NSS.
++ */
++void nss_tunipip6_event_receive(void *if_ctx, struct nss_tunipip6_msg *tnlmsg)
++{
++	struct net_device *netdev = NULL;
++	netdev = (struct net_device *)if_ctx;
++
++	switch (tnlmsg->cm.type) {
++	case NSS_TUNIPIP6_RX_STATS_SYNC:
++		nss_tunipip6_update_dev_stats(netdev, (struct nss_tunipip6_stats_sync_msg *)&tnlmsg->msg.stats_sync);
++		break;
++
++	default:
++		nss_tunipip6_info("%s: Unknown Event from NSS", __func__);
++		break;
++	}
++}
++
++/*
++ * nss_tunipip6_dev_up()
++ *	IPIP6 Tunnel device i/f up handler
++ */
++int nss_tunipip6_dev_up(struct net_device *netdev)
++{
++	struct ip6_tnl *tunnel;
++	struct nss_tunipip6_msg tnlmsg;
++	struct nss_tunipip6_create_msg *tnlcfg;
++	struct flowi6 *fl6;
++	uint32_t fmr_number = 0;
++	int inner_ifnum, outer_ifnum;
++	uint32_t features = 0;
++	nss_tx_status_t status;
++	struct nss_ctx_instance *nss_ctx;
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0))
++	struct __ip6_tnl_fmr *fmr;
++#endif
++
++	/*
++	 * Validate netdev for ipv6-in-ipv4  Tunnel
++	 */
++	if (netdev->type != ARPHRD_TUNNEL6 ) {
++		return NOTIFY_DONE;
++	}
++
++	tunnel = (struct ip6_tnl *)netdev_priv(netdev);
++
++	/*
++	 * Find the Tunnel device flow information
++	 */
++	fl6 = &tunnel->fl.u.ip6;
++
++	nss_tunipip6_trace("%p: Tunnel Param srcaddr %x:%x:%x:%x  daddr %x:%x:%x:%x\n", netdev,
++			fl6->saddr.s6_addr32[0], fl6->saddr.s6_addr32[1],
++			fl6->saddr.s6_addr32[2], fl6->saddr.s6_addr32[3],
++			fl6->daddr.s6_addr32[0], fl6->daddr.s6_addr32[1],
++			fl6->daddr.s6_addr32[2], fl6->daddr.s6_addr32[3] );
++	nss_tunipip6_trace("%p: Hop limit %d\n", netdev, tunnel->parms.hop_limit);
++	nss_tunipip6_trace("%p: Tunnel param flag %x  fl6.flowlabel %x\n", netdev,  tunnel->parms.flags, fl6->flowlabel);
++
++	inner_ifnum = nss_dynamic_interface_alloc_node(NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_INNER);
++	if (inner_ifnum < 0) {
++		nss_tunipip6_warning("%p: Request interface number failed\n", netdev);
++		goto inner_alloc_fail;
++	}
++
++	outer_ifnum = nss_dynamic_interface_alloc_node(NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_OUTER);
++	if (outer_ifnum < 0) {
++		nss_tunipip6_warning("%p: Request interface number failed\n", netdev);
++		goto outer_alloc_fail;
++	}
++
++	/*
++	 * Register ipip6 tunnel with NSS
++	 */
++	nss_ctx = nss_register_tunipip6_if(inner_ifnum,
++					NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_INNER,
++					nss_tunipip6_encap_exception,
++					nss_tunipip6_event_receive,
++					netdev,
++					features);
++	if (!nss_ctx) {
++		nss_tunipip6_warning("%p: nss_register_tunipip6_if Failed\n", netdev);
++		goto inner_reg_fail;
++	}
++
++	nss_ctx = nss_register_tunipip6_if(outer_ifnum,
++					NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_OUTER,
++					nss_tunipip6_decap_exception,
++					nss_tunipip6_event_receive,
++					netdev,
++					features);
++	if (!nss_ctx) {
++		nss_tunipip6_warning("%p: nss_register_tunipip6_if Failed\n", netdev);
++		goto outer_reg_fail;
++	}
++
++	nss_tunipip6_trace("%p: nss_register_tunipip6_if Success\n", netdev);
++
++	/*
++	 * Prepare The Tunnel configuration parameter to send to nss
++	 */
++	memset(&tnlmsg, 0, sizeof(struct nss_tunipip6_msg));
++	tnlcfg = &tnlmsg.msg.tunipip6_create;
++
++	tnlcfg->saddr[0] = ntohl(fl6->saddr.s6_addr32[0]);
++	tnlcfg->saddr[1] = ntohl(fl6->saddr.s6_addr32[1]);
++	tnlcfg->saddr[2] = ntohl(fl6->saddr.s6_addr32[2]);
++	tnlcfg->saddr[3] = ntohl(fl6->saddr.s6_addr32[3]);
++	tnlcfg->daddr[0] = ntohl(fl6->daddr.s6_addr32[0]);
++	tnlcfg->daddr[1] = ntohl(fl6->daddr.s6_addr32[1]);
++	tnlcfg->daddr[2] = ntohl(fl6->daddr.s6_addr32[2]);
++	tnlcfg->daddr[3] = ntohl(fl6->daddr.s6_addr32[3]);
++	tnlcfg->hop_limit = tunnel->parms.hop_limit;
++	tnlcfg->flags = ntohl(tunnel->parms.flags);
++
++	/*
++	 * Flow Label In kernel is stored in big endian format.
++	 */
++	tnlcfg->flowlabel = fl6->flowlabel;
++	tnlcfg->draft03 = tunnel->parms.draft03;
++
++	/*
++	 * Configure FMR table up to MAX_FMR_NUMBER, the rest will be forwarded to BR
++	 */
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0))
++	for (fmr = tunnel->parms.fmrs; fmr && fmr_number < NSS_TUNIPIP6_MAX_FMR_NUMBER; fmr = fmr->next, fmr_number++) {
++		tnlcfg->fmr[fmr_number].ip6_prefix[0] = ntohl(fmr->ip6_prefix.s6_addr32[0]);
++		tnlcfg->fmr[fmr_number].ip6_prefix[1] = ntohl(fmr->ip6_prefix.s6_addr32[1]);
++		tnlcfg->fmr[fmr_number].ip6_prefix[2] = ntohl(fmr->ip6_prefix.s6_addr32[2]);
++		tnlcfg->fmr[fmr_number].ip6_prefix[3] = ntohl(fmr->ip6_prefix.s6_addr32[3]);
++		tnlcfg->fmr[fmr_number].ip4_prefix = ntohl(fmr->ip4_prefix.s_addr);
++		tnlcfg->fmr[fmr_number].ip6_prefix_len = fmr->ip6_prefix_len;
++		tnlcfg->fmr[fmr_number].ip4_prefix_len = fmr->ip4_prefix_len;
++		tnlcfg->fmr[fmr_number].ea_len = fmr->ea_len;
++		tnlcfg->fmr[fmr_number].offset = fmr->offset;
++	}
++#endif
++	tnlcfg->fmr_number = fmr_number;
++
++	/*
++	 * Updating sibling_if_num for encap interface.
++	 */
++	tnlcfg->sibling_if_num = outer_ifnum;
++
++	nss_tunipip6_trace("%p: Tunnel Param srcaddr %x:%x:%x:%x  daddr %x:%x:%x:%x\n", netdev,
++			tnlcfg->saddr[0], tnlcfg->saddr[1],
++			tnlcfg->saddr[2], tnlcfg->saddr[3],
++			tnlcfg->daddr[0], tnlcfg->daddr[1],
++			tnlcfg->daddr[2], tnlcfg->daddr[3] );
++
++	/*
++	 * Send configure message to encap interface.
++	 */
++	nss_tunipip6_msg_init(&tnlmsg, inner_ifnum, NSS_TUNIPIP6_TX_ENCAP_IF_CREATE,
++			sizeof(struct nss_tunipip6_create_msg), NULL, NULL);
++
++	nss_tunipip6_trace("%p: Sending IPIP6 tunnel i/f up command to NSS %p\n", netdev, nss_ctx);
++	status = nss_tunipip6_tx(nss_ctx, &tnlmsg);
++	if (status != NSS_TX_SUCCESS) {
++		nss_tunipip6_warning("%p: Tunnel up command error %d\n", netdev, status);
++		goto config_fail;
++	}
++
++	/*
++	 * Updating sibling_if_num for decap interface.
++	 */
++	tnlcfg->sibling_if_num = inner_ifnum;
++
++	/*
++	 * Send configure message to decap interface.
++	 */
++	nss_tunipip6_msg_init(&tnlmsg, outer_ifnum, NSS_TUNIPIP6_TX_DECAP_IF_CREATE,
++			sizeof(struct nss_tunipip6_create_msg), NULL, NULL);
++
++	nss_tunipip6_trace("%p: Sending IPIP6 tunnel i/f up command to NSS %p\n", netdev, nss_ctx);
++	status = nss_tunipip6_tx(nss_ctx, &tnlmsg);
++	if (status != NSS_TX_SUCCESS) {
++		nss_tunipip6_warning("%p: Tunnel up command error %d\n", netdev, status);
++		goto config_fail;
++	}
++	return NOTIFY_DONE;
++
++config_fail:
++	nss_unregister_tunipip6_if(outer_ifnum);
++outer_reg_fail:
++	nss_unregister_tunipip6_if(inner_ifnum);
++inner_reg_fail:
++	status = nss_dynamic_interface_dealloc_node(outer_ifnum, NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_OUTER);
++	if (status != NSS_TX_SUCCESS) {
++		nss_tunipip6_warning("%p: Unable to dealloc the node[%d] in the NSS fw!\n", netdev, outer_ifnum);
++	}
++outer_alloc_fail:
++	status = nss_dynamic_interface_dealloc_node(inner_ifnum, NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_INNER);
++	if (status != NSS_TX_SUCCESS) {
++		nss_tunipip6_warning("%p: Unable to dealloc the node[%d] in the NSS fw!\n", netdev, inner_ifnum);
++	}
++inner_alloc_fail:
++	return NOTIFY_DONE;
++}
++
++/*
++ * nss_tunipip6_dev_down()
++ *	IPP6 Tunnel device i/f down handler
++ */
++int nss_tunipip6_dev_down(struct net_device *netdev)
++{
++	int inner_ifnum, outer_ifnum;
++	nss_tx_status_t status;
++
++	/*
++	 * Validate netdev for ipv6-in-ipv4  Tunnel
++	 */
++	if (netdev->type != ARPHRD_TUNNEL6) {
++		return NOTIFY_DONE;
++	}
++
++	/*
++	 * Check if tunnel ipip6 is registered ?
++	 */
++	inner_ifnum = nss_cmn_get_interface_number_by_dev_and_type(netdev, NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_INNER);
++	if (inner_ifnum < 0) {
++		nss_tunipip6_warning("%p: Net device is not registered with nss\n", netdev);
++		return NOTIFY_DONE;
++	}
++
++	outer_ifnum = nss_cmn_get_interface_number_by_dev_and_type(netdev, NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_OUTER);
++	if (outer_ifnum < 0) {
++		nss_tunipip6_warning("%p: Net device is not registered with nss\n", netdev);
++		return NOTIFY_DONE;
++	}
++
++	/*
++	 * Un-Register IPIP6 tunnel with NSS
++	 */
++	nss_unregister_tunipip6_if(inner_ifnum);
++	nss_unregister_tunipip6_if(outer_ifnum);
++
++	status = nss_dynamic_interface_dealloc_node(inner_ifnum, NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_INNER);
++	if (status != NSS_TX_SUCCESS) {
++		nss_tunipip6_warning("%p: Dealloc node failure\n", netdev);
++		return NOTIFY_DONE;
++	}
++
++	status = nss_dynamic_interface_dealloc_node(outer_ifnum, NSS_DYNAMIC_INTERFACE_TYPE_TUNIPIP6_OUTER);
++	if (status != NSS_TX_SUCCESS) {
++		nss_tunipip6_warning("%p: Dealloc node failure\n", netdev);
++		return NOTIFY_DONE;
++	}
++
++	return NOTIFY_DONE;
++}
++
++/*
++ * nss_tunipip6_dev_event()
++ *	Net device notifier for ipip6 module
++ */
++static int nss_tunipip6_dev_event(struct notifier_block  *nb,
++		unsigned long event, void  *dev)
++{
++#if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 10, 0))
++	struct net_device *netdev = (struct net_device *)dev;
++#else
++	struct net_device *netdev = netdev_notifier_info_to_dev(dev);
++#endif
++
++	switch (event) {
++	case NETDEV_UP:
++		nss_tunipip6_trace("%p: NETDEV_UP :event %lu name %s\n", netdev, event, netdev->name);
++		return nss_tunipip6_dev_up(netdev);
++
++	case NETDEV_DOWN:
++		nss_tunipip6_trace("%p: NETDEV_DOWN :event %lu name %s\n", netdev, event, netdev->name);
++		return nss_tunipip6_dev_down(netdev);
++
++	default:
++		nss_tunipip6_trace("%p: Unhandled notifier dev %s event %x\n", netdev, netdev->name, (int)event);
++		break;
++	}
++
++	return NOTIFY_DONE;
++}
++
++/*
++ * Linux Net device Notifier
++ */
++struct notifier_block nss_tunipip6_notifier = {
++	.notifier_call = nss_tunipip6_dev_event,
++};
++
++/*
++ * nss_tunipip6_init_module()
++ *	Tunnel ipip6 module init function
++ */
++int __init nss_tunipip6_init_module(void)
++{
++#ifdef CONFIG_OF
++	/*
++	 * If the node is not compatible, don't do anything.
++	 */
++	if (!of_find_node_by_name(NULL, "nss-common")) {
++		return 0;
++	}
++#endif
++	nss_tunipip6_info("module (platform - IPQ806x , %s) loaded\n",
++			  NSS_CLIENT_BUILD_ID);
++
++	register_netdevice_notifier(&nss_tunipip6_notifier);
++	nss_tunipip6_trace("Netdev Notifier registerd\n");
++
++
++	return 0;
++}
++
++/*
++ * nss_tunipip6_exit_module()
++ *	Tunnel ipip6 module exit function
++ */
++void __exit nss_tunipip6_exit_module(void)
++{
++#ifdef CONFIG_OF
++
++	/*
++	 * If the node is not compatible, don't do anything.
++	 */
++	if (!of_find_node_by_name(NULL, "nss-common")) {
++		return;
++	}
++#endif
++
++	unregister_netdevice_notifier(&nss_tunipip6_notifier);
++	nss_tunipip6_info("module unloaded\n");
++}
++
++module_init(nss_tunipip6_init_module);
++module_exit(nss_tunipip6_exit_module);
++
++MODULE_LICENSE("Dual BSD/GPL");
++MODULE_DESCRIPTION("NSS tunipip6 offload manager");

--- a/qca-nss-drv/patches/0014-revert-tunipip6-11.2.patch
+++ b/qca-nss-drv/patches/0014-revert-tunipip6-11.2.patch
@@ -1,0 +1,393 @@
+--- a/exports/nss_tunipip6.h	2022-10-11 22:04:19.150000000 +0900
++++ b/exports/nss_tunipip6.h	2022-10-11 22:06:00.000000000 +0900
+@@ -1,6 +1,6 @@
+ /*
+  **************************************************************************
+- * Copyright (c) 2014, 2017-2018, 2020, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2014, 2017-2018, The Linux Foundation. All rights reserved.
+  * Permission to use, copy, modify, and/or distribute this software for
+  * any purpose with or without fee is hereby granted, provided that the
+  * above copyright notice and this permission notice appear in all copies.
+@@ -30,18 +30,16 @@
+ #define NSS_TUNIPIP6_MAX_FMR_NUMBER 4	/**< Maximum number of forward mapping rule (FMR). */
+ 
+ /**
+- * nss_tunipip6_map_rule
+- *	Mapping rule (FMR/BMR) for forwarding traffic to the node in the same domain.
++ * nss_tunipip6_fmr
++ *	Forward mapping rule (FMR) for direct forwarding traffic to the node in the same domain.
+  */
+-struct nss_tunipip6_map_rule {
++struct nss_tunipip6_fmr {
+ 	uint32_t ip6_prefix[4];		/**< An IPv6 prefix assigned by a mapping rule. */
+ 	uint32_t ip4_prefix;		/**< An IPv4 prefix assigned by a mapping rule. */
+ 	uint32_t ip6_prefix_len;	/**< IPv6 prefix length. */
+ 	uint32_t ip4_prefix_len;	/**< IPv4 prefix length. */
+-	uint32_t ip6_suffix[4];		/**< IPv6 suffix. */
+-	uint32_t ip6_suffix_len;	/**< IPv6 suffix length. */
+ 	uint32_t ea_len;		/**< Embedded Address (EA) bits. */
+-	uint32_t psid_offset;		/**< PSID offset default 6. */
++	uint32_t offset;		/**< PSID offset default 6. */
+ };
+ 
+ /**
+@@ -52,11 +50,6 @@ enum nss_tunipip6_metadata_types {
+ 	NSS_TUNIPIP6_TX_ENCAP_IF_CREATE,
+ 	NSS_TUNIPIP6_TX_DECAP_IF_CREATE,
+ 	NSS_TUNIPIP6_RX_STATS_SYNC,
+-	NSS_TUNIPIP6_FMR_RULE_ADD,
+-	NSS_TUNIPIP6_FMR_RULE_DEL,
+-	NSS_TUNIPIP6_FMR_RULE_FLUSH,
+-	NSS_TUNIPIP6_BMR_RULE_ADD,
+-	NSS_TUNIPIP6_BMR_RULE_DEL,
+ 	NSS_TUNIPIP6_MAX,
+ };
+ 
+@@ -65,16 +58,16 @@ enum nss_tunipip6_metadata_types {
+  *	Payload for configuring the DS-Lite interface.
+  */
+ struct nss_tunipip6_create_msg {
++	struct nss_tunipip6_fmr fmr[NSS_TUNIPIP6_MAX_FMR_NUMBER];	/**< Tunnel FMR array. */
+ 	uint32_t saddr[4];						/**< Tunnel source address. */
+ 	uint32_t daddr[4];						/**< Tunnel destination address. */
+ 	uint32_t flowlabel;						/**< Tunnel IPv6 flow label. */
+ 	uint32_t flags;							/**< Tunnel additional flags. */
++	uint32_t fmr_number;						/**< Tunnel FMR number. */
+ 	uint32_t sibling_if_num;					/**< Sibling interface number. */
++	uint16_t reserved1;						/**< Reserved for alignment. */
+ 	uint8_t hop_limit;						/**< Tunnel IPv6 hop limit. */
+ 	uint8_t draft03;						/**< Use MAP-E draft03 specification. */
+-	bool ttl_inherit;						/**< Inherit IPv4 TTL to hoplimit. */
+-	bool tos_inherit;						/**< Inherit IPv4 ToS. */
+-	bool frag_id_update;						/**< Enable update of fragment identifier of IPv4. */
+ };
+ 
+ /**
+@@ -97,12 +90,10 @@ struct nss_tunipip6_msg {
+ 	 */
+ 	union {
+ 		struct nss_tunipip6_create_msg tunipip6_create;
+-				/**< Create a DS-Lite/IPIP6 tunnel. */
++				/**< Create a DS-Lite tunnel. */
+ 		struct nss_tunipip6_stats_sync_msg stats_sync;
+ 				/**< Synchronized statistics for the DS-Lite interface. */
+-		struct nss_tunipip6_map_rule map_rule;
+-				/**< BMR/FMR rule to add/delete, new or existing rules. */
+-	} msg;			/**< Message payload for IPIP6 tunnel messages exchanged with NSS core. */
++	} msg;			/**< Message payload for IPIP6 Tunnel messages exchanged with NSS core. */
+ };
+ 
+ /**
+@@ -133,22 +124,6 @@ typedef void (*nss_tunipip6_msg_callback
+ extern nss_tx_status_t nss_tunipip6_tx(struct nss_ctx_instance *nss_ctx, struct nss_tunipip6_msg *msg);
+ 
+ /**
+- * nss_tunipip6_tx_sync
+- *	Sends a DS-Lite message to NSS core synchronously.
+- *
+- * @datatypes
+- * nss_ctx_instance \n
+- * nss_tunipip6_msg
+- *
+- * @param[in] nss_ctx  Pointer to the NSS context.
+- * @param[in] msg      Pointer to the message data.
+- *
+- * @return
+- * Status of the Tx operation.
+- */
+-extern nss_tx_status_t nss_tunipip6_tx_sync(struct nss_ctx_instance *nss_ctx, struct nss_tunipip6_msg *msg);
+-
+-/**
+  * Callback function for receiving DS-Lite data.
+  *
+  * @datatypes
+--- a/nss_tunipip6.c	2022-10-11 22:04:19.170000000 +0900
++++ b/nss_tunipip6.c	2022-10-11 22:07:56.000000000 +0900
+@@ -1,6 +1,6 @@
+ /*
+  **************************************************************************
+- * Copyright (c) 2014-2018, 2020, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2014-2018, The Linux Foundation. All rights reserved.
+  * Permission to use, copy, modify, and/or distribute this software for
+  * any purpose with or without fee is hereby granted, provided that the
+  * above copyright notice and this permission notice appear in all copies.
+@@ -17,19 +17,6 @@
+ #include "nss_tx_rx_common.h"
+ #include "nss_tunipip6_log.h"
+ 
+-#define NSS_TUNIPIP6_TX_TIMEOUT 3000
+-
+-/*
+- * Data structure used to handle sync message.
+- */
+-static struct nss_tunipip6_pvt {
+-	struct semaphore sem;           /* Semaphore structure. */
+-	struct completion complete;     /* Completion structure. */
+-	int response;                   /* Response from FW. */
+-	void *cb;                       /* Original cb for msgs. */
+-	void *app_data;                 /* Original app_data for msgs. */
+-} tunipip6_pvt;
+-
+ /*
+  * nss_tunipip6_verify_if_num
+  *	Verify the interface is a valid interface
+@@ -70,12 +57,12 @@ static void nss_tunipip6_handler(struct
+ 	 * Is this a valid request/response packet?
+ 	 */
+ 	if (ncm->type >= NSS_TUNIPIP6_MAX) {
+-		nss_warning("%px: received invalid message %d for DS-Lite interface", nss_ctx, ncm->type);
++		nss_warning("%p: received invalid message %d for DS-Lite interface", nss_ctx, ncm->type);
+ 		return;
+ 	}
+ 
+ 	if (nss_cmn_get_msg_len(ncm) > sizeof(struct nss_tunipip6_msg)) {
+-		nss_warning("%px: Length of message is greater than required: %d", nss_ctx, nss_cmn_get_msg_len(ncm));
++		nss_warning("%p: Length of message is greater than required: %d", nss_ctx, nss_cmn_get_msg_len(ncm));
+ 		return;
+ 	}
+ 
+@@ -109,7 +96,7 @@ static void nss_tunipip6_handler(struct
+ 	 * call ipip6 tunnel callback
+ 	 */
+ 	if (!ctx) {
+-		 nss_warning("%px: Event received for DS-Lite tunnel interface %d before registration", nss_ctx, ncm->interface);
++		 nss_warning("%p: Event received for DS-Lite tunnel interface %d before registration", nss_ctx, ncm->interface);
+ 		return;
+ 	}
+ 
+@@ -133,12 +120,12 @@ nss_tx_status_t nss_tunipip6_tx(struct n
+ 	 * Sanity check the message
+ 	 */
+ 	if (!nss_tunipip6_verify_if_num(ncm->interface)) {
+-		nss_warning("%px: tx request for another interface: %d", nss_ctx, ncm->interface);
++		nss_warning("%p: tx request for another interface: %d", nss_ctx, ncm->interface);
+ 		return NSS_TX_FAILURE;
+ 	}
+ 
+ 	if (ncm->type > NSS_TUNIPIP6_MAX) {
+-		nss_warning("%px: message type out of range: %d", nss_ctx, ncm->type);
++		nss_warning("%p: message type out of range: %d", nss_ctx, ncm->type);
+ 		return NSS_TX_FAILURE;
+ 	}
+ 
+@@ -147,60 +134,6 @@ nss_tx_status_t nss_tunipip6_tx(struct n
+ EXPORT_SYMBOL(nss_tunipip6_tx);
+ 
+ /*
+- * nss_tunipip6_callback()
+- *	Callback to handle the completion of NSS->HLOS messages.
+- */
+-static void nss_tunipip6_callback(void *app_data, struct nss_tunipip6_msg *nclm)
+-{
+-	tunipip6_pvt.response = NSS_TX_SUCCESS;
+-	tunipip6_pvt.cb = NULL;
+-	tunipip6_pvt.app_data = NULL;
+-
+-	if (nclm->cm.response != NSS_CMN_RESPONSE_ACK) {
+-		nss_warning("%px: tunipip6 Error response %d Error: %d\n", app_data, nclm->cm.response, nclm->cm.error);
+-		tunipip6_pvt.response = nclm->cm.response;
+-	}
+-
+-	/*
+-	 * Write memory barrier.
+-	 */
+-	smp_wmb();
+-	complete(&tunipip6_pvt.complete);
+-}
+-
+-/*
+- * nss_tunipip6_tx_sync()
+- * 	Transmit a tunipip6 message to NSSFW synchronously.
+- */
+-nss_tx_status_t nss_tunipip6_tx_sync(struct nss_ctx_instance *nss_ctx, struct nss_tunipip6_msg *msg)
+-{
+-	nss_tx_status_t status;
+-	int ret;
+-
+-	down(&tunipip6_pvt.sem);
+-	msg->cm.cb = (nss_ptr_t)nss_tunipip6_callback;
+-	msg->cm.app_data = (nss_ptr_t)NULL;
+-
+-	status = nss_tunipip6_tx(nss_ctx, msg);
+-	if (status != NSS_TX_SUCCESS) {
+-		nss_warning("%px: tunipip6_tx_msg failed\n", nss_ctx);
+-		up(&tunipip6_pvt.sem);
+-		return status;
+-	}
+-
+-	ret = wait_for_completion_timeout(&tunipip6_pvt.complete, msecs_to_jiffies(NSS_TUNIPIP6_TX_TIMEOUT));
+-	if (!ret) {
+-		nss_warning("%px: tunipip6 tx sync failed due to timeout\n", nss_ctx);
+-		tunipip6_pvt.response = NSS_TX_FAILURE;
+-	}
+-
+-	status = tunipip6_pvt.response;
+-	up(&tunipip6_pvt.sem);
+-	return status;
+-}
+-EXPORT_SYMBOL(nss_tunipip6_tx_sync);
+-
+-/*
+  * **********************************
+  *  Register/Unregister/Miscellaneous APIs
+  * **********************************
+@@ -264,8 +197,6 @@ void nss_tunipip6_register_handler()
+ 	struct nss_ctx_instance *nss_ctx = nss_tunipip6_get_context();
+ 
+ 	nss_core_register_handler(nss_ctx, NSS_TUNIPIP6_INTERFACE, nss_tunipip6_handler, NULL);
+-	sema_init(&tunipip6_pvt.sem, 1);
+-	init_completion(&tunipip6_pvt.complete);
+ }
+ 
+ /*
+--- a/nss_tunipip6_log.c	2022-10-11 22:04:19.170000000 +0900
++++ b/nss_tunipip6_log.c	2022-10-11 22:08:22.000000000 +0900
+@@ -1,6 +1,6 @@
+ /*
+  **************************************************************************
+- * Copyright (c) 2018, 2020, The Linux Foundation. All rights reserved.
++ * Copyright (c) 2018, The Linux Foundation. All rights reserved.
+  * Permission to use, copy, modify, and/or distribute this software for
+  * any purpose with or without fee is hereby granted, provided that the
+  * above copyright notice and this permission notice appear in all copies.
+@@ -26,63 +26,47 @@
+  *	NSS TUNIPIP6 message strings
+  */
+ static int8_t *nss_tunipip6_log_message_types_str[NSS_TUNIPIP6_MAX] __maybe_unused = {
+-	"TUNIPIP6 Encap Interface Create",
+-	"TUNIPIP6 Decap Interface Create",
++	"TUNIPIP6 Interface Create",
+ 	"TUNIPIP6 Stats",
+-	"TUNIPIP6 FMR add",
+-	"TUNIPIP6 FMR delete",
+-	"TUNIPIP6 FMR flush",
+-	"TUNIPIP6 BMR add",
+-	"TUNIPIP6 BMR delete",
+ };
+ 
+ /*
+- * nss_tunipip6_log_map_rule()
+- *	Log NSS TUNIPIP6 map rule.
+- */
+-static void nss_tunipip6_log_map_rule(struct nss_tunipip6_msg *ntm)
+-{
+-	struct nss_tunipip6_map_rule *nmr __maybe_unused = &ntm->msg.map_rule;
+-	nss_trace("%px: NSS TUNIPIP6 Interface Create message \n"
+-		"TUNIPIP6 Map Rule IPv6 prefix: %pI6\n"
+-		"TUNIPIP6 Map Rule IPv6 prefix length: %d\n"
+-		"TUNIPIP6 Map Rule IPv4 prefix: %pI4\n"
+-		"TUNIPIP6 Map Rule IPv4 prefix length: %d\n"
+-		"TUNIPIP6 Map Rule IPv6 suffix: %pI6\n"
+-		"TUNIPIP6 Map Rule IPv6 suffix length: %d\n"
+-		"TUNIPIP6 Map Rule EA length: %d\n"
+-		"TUNIPIP6 Map Rule PSID offset: %d\n",
+-		nmr, nmr->ip6_prefix,
+-		nmr->ip6_prefix_len,&nmr->ip4_prefix,
+-		nmr->ip4_prefix_len, nmr->ip6_suffix,
+-		nmr->ip6_suffix_len, nmr->ea_len,
+-		nmr->psid_offset);
+-}
+-
+-/*
+  * nss_tunipip6_log_if_create_msg()
+  *	Log NSS TUNIPIP6 Interface Create
+  */
+ static void nss_tunipip6_log_if_create_msg(struct nss_tunipip6_msg *ntm)
+ {
+ 	struct nss_tunipip6_create_msg *ntcm __maybe_unused = &ntm->msg.tunipip6_create;
+-	nss_trace("%px: NSS TUNIPIP6 Interface Create message \n"
++	int32_t i;
++	nss_trace("%p: NSS TUNIPIP6 Interface Create message \n"
+ 		"TUNIPIP6 Source Address: %pI6\n"
+ 		"TUNIPIP6 Destination Address: %pI6\n"
+ 		"TUNIPIP6 Flow Label: %d\n"
+ 		"TUNIPIP6 Flags: %d\n"
+ 		"TUNIPIP6 Hop Limit: %d\n"
+ 		"TUNIPIP6 Draft03 Specification: %d\n"
+-		"TUNIPIP6 TTL inherit: %s\n"
+-		"TUNIPIP6 TOS inherit: %s\n"
+-		"TUNIPIP6 Frag ID Update: %s\n",
++		"TUNIPIP6 FMR Number: %d\n",
+ 		ntcm, ntcm->saddr,
+ 		ntcm->daddr, ntcm->flowlabel,
+ 		ntcm->flags, ntcm->hop_limit,
+-		ntcm->draft03,
+-		ntcm->ttl_inherit ? "true":"false",
+-		ntcm->tos_inherit ? "true":"false",
+-		ntcm->frag_id_update ? "true":"false");
++		ntcm->draft03, ntcm->fmr_number);
++	/*
++	 * Continuation of the log.
++	 */
++	for (i = 0; i < NSS_TUNIPIP6_MAX_FMR_NUMBER; i++) {
++		nss_trace("TUNIPIP6 FMR[%d] IPv6 Prefix: %pI6\n"
++			"TUNIPIP6 FMR[%d] IPv4 Prefix: %pI4\n"
++			"TUNIPIP6 FMR[%d] IPv6 Prefix Length: %d\n"
++			"TUNIPIP6 FMR[%d] IPv4 Prefix Length: %d\n"
++			"TUNIPIP6 FMR[%d] Embedded Address Length: %d\n"
++			"TUNIPIP6 FMR[%d] offset: %d",
++			i, ntcm->fmr[i].ip6_prefix,
++			i, &ntcm->fmr[i].ip4_prefix,
++			i, ntcm->fmr[i].ip6_prefix_len,
++			i, ntcm->fmr[i].ip4_prefix_len,
++			i, ntcm->fmr[i].ea_len,
++			i, ntcm->fmr[i].offset);
++	}
+ }
+ 
+ /*
+@@ -103,17 +87,8 @@ static void nss_tunipip6_log_verbose(str
+ 		 */
+ 		break;
+ 
+-	case NSS_TUNIPIP6_BMR_RULE_ADD:
+-	case NSS_TUNIPIP6_BMR_RULE_DEL:
+-	case NSS_TUNIPIP6_FMR_RULE_ADD:
+-	case NSS_TUNIPIP6_FMR_RULE_DEL:
+-		nss_tunipip6_log_map_rule(ntm);
+-		break;
+-	case NSS_TUNIPIP6_FMR_RULE_FLUSH:
+-		nss_trace("%px: FMR rule flush.\n", ntm);
+-		break;
+ 	default:
+-		nss_trace("%px: Invalid message type\n", ntm);
++		nss_trace("%p: Invalid message type\n", ntm);
+ 		break;
+ 	}
+ }
+@@ -125,11 +100,11 @@ static void nss_tunipip6_log_verbose(str
+ void nss_tunipip6_log_tx_msg(struct nss_tunipip6_msg *ntm)
+ {
+ 	if (ntm->cm.type >= NSS_TUNIPIP6_MAX) {
+-		nss_warning("%px: Invalid message type\n", ntm);
++		nss_warning("%p: Invalid message type\n", ntm);
+ 		return;
+ 	}
+ 
+-	nss_info("%px: type[%d]:%s\n", ntm, ntm->cm.type, nss_tunipip6_log_message_types_str[ntm->cm.type]);
++	nss_info("%p: type[%d]:%s\n", ntm, ntm->cm.type, nss_tunipip6_log_message_types_str[ntm->cm.type]);
+ 	nss_tunipip6_log_verbose(ntm);
+ }
+ 
+@@ -140,18 +115,18 @@ void nss_tunipip6_log_tx_msg(struct nss_
+ void nss_tunipip6_log_rx_msg(struct nss_tunipip6_msg *ntm)
+ {
+ 	if (ntm->cm.response >= NSS_CMN_RESPONSE_LAST) {
+-		nss_warning("%px: Invalid response\n", ntm);
++		nss_warning("%p: Invalid response\n", ntm);
+ 		return;
+ 	}
+ 
+ 	if (ntm->cm.response == NSS_CMN_RESPONSE_NOTIFY || (ntm->cm.response == NSS_CMN_RESPONSE_ACK)) {
+-		nss_info("%px: type[%d]:%s, response[%d]:%s\n", ntm, ntm->cm.type,
++		nss_info("%p: type[%d]:%s, response[%d]:%s\n", ntm, ntm->cm.type,
+ 			nss_tunipip6_log_message_types_str[ntm->cm.type],
+ 			ntm->cm.response, nss_cmn_response_str[ntm->cm.response]);
+ 		goto verbose;
+ 	}
+ 
+-	nss_info("%px: msg nack - type[%d]:%s, response[%d]:%s\n",
++	nss_info("%p: msg nack - type[%d]:%s, response[%d]:%s\n",
+ 		ntm, ntm->cm.type, nss_tunipip6_log_message_types_str[ntm->cm.type],
+ 		ntm->cm.response, nss_cmn_response_str[ntm->cm.response]);
+ 

--- a/qca-nss-gmac/patches/0010-irq_of_parse_and_map-retcode.patch
+++ b/qca-nss-gmac/patches/0010-irq_of_parse_and_map-retcode.patch
@@ -1,0 +1,11 @@
+--- a/ipq806x/nss_gmac_ctrl.c	2022-10-05 20:55:15.080000000 +0900
++++ b/ipq806x/nss_gmac_ctrl.c	2022-10-05 20:55:46.050000000 +0900
+@@ -1027,7 +1027,7 @@ static int32_t nss_gmac_of_get_pdata(str
+ 
+ 	gmaccfg->phy_mii_type = of_get_phy_mode(np, &phyif);
+ 	netdev->irq = irq_of_parse_and_map(np, 0);
+-	if (netdev->irq == NO_IRQ) {
++	if (!netdev->irq) {
+ 		pr_err("%s: Can't map interrupt\n", np->name);
+ 		return -EFAULT;
+ 	}


### PR DESCRIPTION
revert qca-nss-tunipip6 QSDK11.2 to fix NSS firmware core dump for NSS-11.2-K5.15 branch.
retcode zero is false in irq_of_parse_and_map().
