### PR TITLE
replace insmod/rmmod with modprobe [-r]

### DIFF
--- a/qca-nss-clients/files/qca-nss-ipsec
+++ b/qca-nss-clients/files/qca-nss-ipsec
@@ -94,7 +94,7 @@ start_klips() {
 
 	local kernel_version=$(uname -r)
 
-	insmod /lib/modules/${kernel_version}/qca-nss-ipsec-klips.ko
+	modprobe /lib/modules/${kernel_version}/qca-nss-ipsec-klips.ko
 	if [ "$?" -gt 0 ]; then
 		echo "Failed to load plugin. Please start ecm if not done already"
 		ecm_enable
@@ -123,7 +123,7 @@ stop_klips() {
 	ecm_disable
 
 	/etc/init.d/ipsec stop
-	rmmod qca-nss-ipsec-klips
+	modprobe -r qca-nss-ipsec-klips
 	rm $NSS_IPSEC_OL_FILE
 
 	ecm_unload
@@ -140,11 +140,11 @@ start_xfrm() {
 		xfrm6_mode_transport xfrm4_mode_transport xfrm4_mode_tunnel \
 		xfrm4_tunnel xfrm4_mode_beet esp4 esp6 ah4 ah6 af_key
 		do
-			insmod $mod 2> /dev/null
+			modprobe $mod 2> /dev/null
 		done
 
 	# Now load the xfrm plugin
-	insmod /lib/modules/${kernel_version}/qca-nss-ipsec-xfrm.ko
+	modprobe /lib/modules/${kernel_version}/qca-nss-ipsec-xfrm.ko
 	if [ "$?" -gt 0 ]; then
 		echo "Failed to load plugin. Please start ecm if not done already"
 		ecm_enable
@@ -183,7 +183,7 @@ stop_xfrm() {
 	retries=5
 	while [ -d /sys/module/qca_nss_ipsec_xfrm ]
 	do
-		rmmod qca-nss-ipsec-xfrm
+		modprobe -r qca-nss-ipsec-xfrm
 		if [ "$?" -eq 0 ]; then
 			rm $NSS_IPSEC_OL_FILE
 			break

--- a/qca-nss-clients/files/qca-nss-mirred.init
+++ b/qca-nss-clients/files/qca-nss-mirred.init
@@ -15,11 +15,11 @@
 ###########################################################################
 
 start() {
-	insmod act_nssmirred.ko
+	modprobe act_nssmirred.ko
 }
 
 stop() {
-	rmmod act_nssmirred.ko
+	modprobe -r act_nssmirred.ko
 }
 
 restart() {

--- a/qca-nss-clients/files/qca-nss-ovpn.init
+++ b/qca-nss-clients/files/qca-nss-ovpn.init
@@ -39,11 +39,11 @@ restart() {
 	ecm_disable
 
 	/etc/init.d/openvpn stop
-	rmmod qca-nss-ovpn-link
-	rmmod qca-nss-ovpn-mgr
+	modprobe -r qca-nss-ovpn-link
+	modprobe -r qca-nss-ovpn-mgr
 
-	insmod qca-nss-ovpn-mgr
-	insmod qca-nss-ovpn-link
+	modprobe qca-nss-ovpn-mgr
+	modprobe qca-nss-ovpn-link
 
 	if [ "$?" -gt 0 ]; then
 		echo "Failed to load plugin. Please start ecm if not done already"
@@ -62,8 +62,8 @@ stop() {
 	ecm_disable
 
 	/etc/init.d/openvpn stop
-	rmmod qca-nss-ovpn-link
-	rmmod qca-nss-ovpn-mgr
+	modprobe -r qca-nss-ovpn-link
+	modprobe -r qca-nss-ovpn-mgr
 
 	ecm_enable
 }

--- a/qca-nss-ecm/files/qca-nss-ecm.init
+++ b/qca-nss-ecm/files/qca-nss-ecm.init
@@ -68,7 +68,7 @@ load_ecm() {
   [ -d /sys/module/ecm ] || {
     local get_front_end_mode
     get_front_end_mode="$(get_front_end_mode)"
-    insmod ecm front_end_selection="$get_front_end_mode"
+    modprobe ecm front_end_selection="$get_front_end_mode"
     echo 1 > /sys/kernel/debug/ecm/ecm_classifier_default/accel_delay_pkts
   }
 
@@ -112,7 +112,7 @@ unload_ecm() {
     echo f > /proc/net/nf_conntrack
 
     sleep 1
-    rmmod ecm
+    modprobe -r ecm
   fi
 }
 
@@ -133,7 +133,7 @@ start() {
   fi
 
   if [ -d /sys/module/qca_ovsmgr ]; then
-    insmod ecm_ovs
+    modprobe ecm_ovs
   fi
 }
 
@@ -147,7 +147,7 @@ stop() {
   [ -d /sys/kernel/debug/ecm/ecm_nss_ipv4 ] && sysctl -w dev.nss.general.redirect=0
 
   if [ -d /sys/module/ecm_ovs ]; then
-    rmmod ecm_ovs
+    modprobe -r ecm_ovs
   fi
 
   unload_ecm


### PR DESCRIPTION
on my kernel-6.6.22 NSS build for a dynalink wrx36, I noticed that the `qca-nss-*` init scripts were failing to load the required kernel modules when I ran

    service qca-nss-<...> [re]start

I went through the various `/etc/init.d/qca-nss-*` scripts and replaced all occurrences of `insmod` with `modprobe` and all occurrences of `rmmod` with `modprobe -r`. After this, the services could correctly load/unload the relevant `qca-nss-*` kmods.

Im not sure if this problem occurs on devices other than the dynalink wrx36, and my config has been customized enough Im not even sure if `modprobe` comes standard. But, this fix made things work right for me.