### PR TITLE
Better handling of NSS core affinity

### DIFF
--- a/qca-nss-drv/files/qca-nss-drv.init
+++ b/qca-nss-drv/files/qca-nss-drv.init
@@ -50,10 +50,13 @@ enable_rps() {
   set_affinity 'nss_queue2' 1 2
   set_affinity 'nss_queue3' 2 2
 
-  # assign nss buffer sos/queues to core 3
-  set_affinity 'nss_empty_buf_sos' 8
-  set_affinity 'nss_empty_buf_queue' 8
-  set_affinity_last 'nss_empty_buf_sos' 8
+  # NSS core 0 buffer sos/queues : CPU2 + CPU3
+  set_affinity 'nss_empty_buf_sos' 4 1
+  set_affinity 'nss_empty_buf_queue' 8 1
+
+  # NSS core 1 buffer sos/queues : CPU2 + CPU3
+  set_affinity 'nss_empty_buf_sos' 4 2
+  set_affinity 'nss_empty_buf_queue' 8 2
 
   # Enable NSS RPS
   sysctl -w dev.nss.rps.enable=1 > /dev/null 2> /dev/null

--- a/qca-nss-drv/files/qca-nss-drv.init
+++ b/qca-nss-drv/files/qca-nss-drv.init
@@ -18,22 +18,37 @@
 START=70
 
 enable_rps() {
-  set_affinity() {
-    awk "/$1/{ print substr(\$1, 1, length(\$1)-1) }" /proc/interrupts | while read -r irq; do
-      [ -n "$irq" ] && echo "$2" > /proc/irq/"$irq"/smp_affinity
-    done
+  set_affinity(){
+    awk -v irq_name="$1" -v affinity="$2" -v occurrence="$3" '
+    BEGIN{count=0}
+    $NF==irq_name{
+      if(++count==occurrence){
+        sub(/:$/,"",$1);
+        logger -t "ucitrack"
+        system("logger -t \"qca-nss-drv\" \"Pinning IRQ " irq_name " occurance " occurrence " to core " affinity "\"");
+        system("printf " affinity " > /proc/irq/" $1 "/smp_affinity");
+        exit
+      }
+    }' /proc/interrupts
   }
+
   set_affinity_last() {
     awk "/$1/{sub(/:/,\"\");last=\$1} END{print last}" /proc/interrupts | while read -r irq; do
       [ -n "$irq" ] && echo "$2" > /proc/irq/"$irq"/smp_affinity
     done
   }
 
-  # assign 3 nss queues to each core
-  set_affinity 'nss_queue1' 2
-  set_affinity 'nss_queue2' 4
-  set_affinity 'nss_queue3' 8
-  set_affinity 'nss_queue0' 1
+  # NSS core 0 queues : CPU1 CPU2 CPU3 CPU0
+  set_affinity 'nss_queue0' 2 1
+  set_affinity 'nss_queue1' 4 1
+  set_affinity 'nss_queue2' 8 1
+  set_affinity 'nss_queue3' 1 1
+
+  # NSS core 1 queues : CPU2 CPU3 CPU0 CPU1
+  set_affinity 'nss_queue0' 4 2
+  set_affinity 'nss_queue1' 8 2
+  set_affinity 'nss_queue2' 1 2
+  set_affinity 'nss_queue3' 2 2
 
   # assign nss buffer sos/queues to core 3
   set_affinity 'nss_empty_buf_sos' 8


### PR DESCRIPTION
My understanding is the name of the game is to get as much as possible off CPU0.

This update does 3 things:

FIrst of all, it handles both sets of nss_queue0/1/2/3. The previous version only handled the first set. On my 3 ipq807x machines, the set, nss_queue0, still had quite a chunk of interrupts. The set_affinity function has been updated to take a param specifying which occurrence of the irq name we are pinning.

2nd of all, I have updated the logic as follows:

NSS_QUEUE SET 1 = CPU1 CPU2 CPU3 CPU0
NSS_QUEUE SET 2 = CPU2 CPU3 CPU0 CPU1

The reason being that nss_queue0 is always hit the hardest, so this will move a very significant number of interrupts off CPU0.

3rd of all I've added a logger call so we should now see some basic logging where things are pinned to in logread.

Now the caveats:

a) I have both package bash and full gawk installed. This needs to be tested on a setup that has neither.

b) This assumes that things work as they should. What I mean by that is for example, having an IRQ _not_ on CPU0 does not impose a penalty in and of it self. But thats all beyond my pay grade ;)