### PR TITLE
Update quectel.sh

### DIFF
--- a/wwan/app/quectel-cm/files/quectel.sh
+++ b/wwan/app/quectel-cm/files/quectel.sh
@@ -36,6 +36,7 @@ proto_quectel_setup() {
 	json_get_vars pdptype dhcp dhcpv6 sourcefilter delegate ip4table
 	json_get_vars ip6table mtu $PROTO_DEFAULT_OPTIONS
 
+	echo -ne "AT+CFUN=1\r\n" > /dev/ttyUSB2
 	[ -n "$delay" ] && sleep "$delay"
 
 	[ -n "$metric" ] || metric="0"
@@ -66,7 +67,7 @@ proto_quectel_setup() {
 		return 1
 	}
 
-	[ "$pdptype" = "ip" -o "$pdptype" = "ipv4v6" ] && ipv4opt="-4"
+	[ "$pdptype" = "ipv4" -o "$pdptype" = "ipv4v6" ] && ipv4opt="-4"
 	[ "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] && ipv6opt="-6"
 	[ -n "$auth" ] || auth="none"
 
@@ -105,7 +106,7 @@ proto_quectel_setup() {
 		ubus call network add_dynamic "$(json_dump)"
 	fi
 
-	if [ "$pdptype" = "ip" ] || [ "$pdptype" = "ipv4v6" ]; then
+	if [ "$pdptype" = "ipv4" ] || [ "$pdptype" = "ipv4v6" ]; then
 		json_init
 		json_add_string name "${interface}_4"
 		json_add_string ifname "@$interface"


### PR DESCRIPTION
On my Arcadyan AW1000 the built in LTE Modem (EG12-EA) does not make a connection because either this script or the quectel-cm utility doesn't enable the radio. On a fresh boot the radio is in low power mode, at least on my particular device.

Also fixed a couple sections where "ip" should be "ipv4". The modem would connect but not create the virtual _4 device and set up the gateway/routes.