### PR TITLE
Update quectel.sh

### DIFF
--- a/wwan/app/quectel-cm/files/quectel.sh
+++ b/wwan/app/quectel-cm/files/quectel.sh
@@ -148,7 +148,7 @@ proto_quectel_setup() {
 
 		json_init
 		json_add_string name "${interface}_6"
-		json_add_string device "$ifname6"
+		json_add_string ifname "@$interface"
 		[ "$pdptype" = "ipv4v6" ] && json_add_string iface_464xlat "0"
 		json_add_string proto "dhcpv6"
 		proto_add_dynamic_defaults
@@ -165,7 +165,7 @@ proto_quectel_setup() {
 	if [ "$pdptype" = "ipv4" ] || [ "$pdptype" = "ipv4v6" ]; then
 		json_init
 		json_add_string name "${interface}_4"
-		json_add_string device "$ifname4"
+		json_add_string ifname "@$interface"
 		json_add_string proto "dhcp"
 		[ -z "$ip4table" ] || json_add_string ip4table "$ip4table"
 		proto_add_dynamic_defaults


### PR DESCRIPTION
The virtual device is created targeting a non present parent device and wont receive an IP address or set up the routes. Changed virtual device creation "json_add_string device $ifname6" and "$ifname4" to "json_add_string ifname @$interface" to create the virtual dhcp/dhcpv6 interface as an alias of the parent quectel interface. Not sure if this is the correct way to set up the alias interface but it works correctly on my Quectel EG12-EA LTE modem.