### PR TITLE
Update quectel.sh (again)

### DIFF
--- a/wwan/app/quectel-cm/files/quectel.sh
+++ b/wwan/app/quectel-cm/files/quectel.sh
@@ -122,7 +122,12 @@ proto_quectel_setup() {
 	sleep 5
 
 	ifconfig "$ifname" up
-	ifconfig "${ifname}_1" &>"/dev/null" && ifname4="${ifname}_1"
+	
+ 	if [ ifconfig "${ifname}_1" &>"/dev/null" ]; then
+ 		ifname4="${ifname}_1"
+   	else
+    		ifname4="$ifname"
+      	fi
 	
 	if [ "$multiplexing" = 1 ]; then
 		ifconfig "${ifname}_2" &>"/dev/null" && ifname6="${ifname}_2"
@@ -148,7 +153,7 @@ proto_quectel_setup() {
 
 		json_init
 		json_add_string name "${interface}_6"
-		json_add_string ifname "@$interface"
+		json_add_string device "$ifname6"
 		[ "$pdptype" = "ipv4v6" ] && json_add_string iface_464xlat "0"
 		json_add_string proto "dhcpv6"
 		proto_add_dynamic_defaults
@@ -165,7 +170,7 @@ proto_quectel_setup() {
 	if [ "$pdptype" = "ipv4" ] || [ "$pdptype" = "ipv4v6" ]; then
 		json_init
 		json_add_string name "${interface}_4"
-		json_add_string ifname "@$interface"
+		json_add_string device "$ifname4"
 		json_add_string proto "dhcp"
 		[ -z "$ip4table" ] || json_add_string ip4table "$ip4table"
 		proto_add_dynamic_defaults

--- a/wwan/app/quectel-cm/files/quectel.sh
+++ b/wwan/app/quectel-cm/files/quectel.sh
@@ -122,7 +122,10 @@ proto_quectel_setup() {
 	sleep 5
 
 	ifconfig "$ifname" up
-	
+
+ 	# If $ifname_1 is not a valid device set $ifname4 to base $ifname as fallback
+  	# so modems not using RMNET/QMAP data aggregation still set up properly. QMAP
+   	# can be set via qmap_mode=n parameter during qmi_wwan_q module loading.
  	if [ ifconfig "${ifname}_1" &>"/dev/null" ]; then
  		ifname4="${ifname}_1"
    	else


### PR DESCRIPTION
Revert previous changes in commit 0c05fe6 as it broke the Virtual Dynamic Interface setup on RG5xx and RG6xx modems that use RMNET/QMAP data aggregation aka wwan0_1, wwan0_2 etc..

Script will now set $ifname4 to base $ifname as a failsafe so modems using a single QMAP interface still set up properly.

You can set QMAP when qmi_wwan_q driver module loads with qmap_mode=n parameter. If n is greater than 1 the driver sets up the extra wwan0_ devices