### PR TITLE
nss-ecm: add ppp_generic dependencies

### DIFF
--- a/qca-nss-ecm/Makefile
+++ b/qca-nss-ecm/Makefile
@@ -32,6 +32,7 @@ define KernelPackage/qca-nss-ecm
 		   +PACKAGE_kmod-bonding:kmod-bonding \
 		   +PACKAGE_kmod-vxlan:kmod-vxlan \
 		   +PACKAGE_kmod-nat46:kmod-nat46 \
+	           +PACKAGE_kmod-ppp:kmod-ppp \
 		   +PACKAGE_kmod-pppoe:kmod-pppoe \
 		   +PACKAGE_kmod-pppoe:kmod-pptp \
 		   +PACKAGE_kmod-pppoe:kmod-pppol2tp \


### PR DESCRIPTION
can`t compile qca-nss-ecm packages in case 'l2tp' I got issue that there is no ppp_generic package. So, this change will fix building for l2tp case and will not broke pppoe case:

```
find /home/nikulove/repos/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/qca-nss-ecm-12.5.5.2024.09.02~bd5057b/ipkg-aarch64_cortex-a53/kmod-qca-nss-ecm -name 'CVS' -o -name '.svn' -o -name '.#*' -o -name '*~'| xargs -r rm -rf
Package kmod-qca-nss-ecm is missing dependencies for the following libraries:
ppp_generic.ko
```