### PR TITLE
resolve dependency between RMNET and WWAN

### DIFF
--- a/qca-nss-drv/Config.in
+++ b/qca-nss-drv/Config.in
@@ -177,7 +177,7 @@ config NSS_DRV_QVPN_ENABLE
 
 config NSS_DRV_RMNET_ENABLE
 	bool
-	default n
+    default y if PACKAGE_kmod-qmi_wwan_q
 	prompt "Enable RMNET"
 	depends on TARGET_qualcommax_ipq807x || TARGET_qualcommax_ipq50xx
 

--- a/qca-nss-ecm/Makefile
+++ b/qca-nss-ecm/Makefile
@@ -165,7 +165,9 @@ ECM_MAKE_OPTS+=ECM_INTERFACE_BOND_ENABLE=y
 endif
 
 ifneq ($(CONFIG_PACKAGE_kmod-qmi_wwan_q),)
+ifneq (, $(findstring $(CONFIG_TARGET_SUBTARGET), "ipq807x" "ipq50xx"))
 ECM_MAKE_OPTS+=ECM_INTERFACE_RAWIP_ENABLE=y
+endif
 endif
 
 ifneq ($(CONFIG_NSS_FIRMWARE_VERSION_12_5),)


### PR DESCRIPTION
I tried to build a firmware for IPQ60xx or IPQ807x device with QModem, but got an error:
```shell
  ERROR: modpost: "nss_rmnet_rx_get_ifnum" [/home/senayuki/Projects/immortalwrt-nss/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq60xx/qca-nss-ecm-12.5.2024.11.06~30fbfa4/ecm.ko] undefined!
```
I found that once `kmod-qmi_wwan_q` is enabled, `ECM_INTERFACE_RAWIP_ENABLE` will be auto-enabled in ECM. But RAWIP requires RMNET feature to be enabled.

So, ECM already auto-enable dependency, I believe that the same logic should also in DRV. When kmod-qmi_wwan_q is enabled, RMNET should be enabled by default in the driver as well.

And, IPQ60xx does not support RMNET, so ECM shoud not to auto-enable it on IPQ60xx.