### PR TITLE
Fix PPP deadlock by using lockless functions

### DIFF
--- a/qca-nss-ecm/patches/0025-ecm_interface-fix-ppp-deadlock-use-lockless-functions.patch
+++ b/qca-nss-ecm/patches/0025-ecm_interface-fix-ppp-deadlock-use-lockless-functions.patch
@@ -1,0 +1,39 @@
+--- a/ecm_interface.c
++++ b/ecm_interface.c
+@@ -3648,7 +3648,7 @@ identifier_update:
+ 		if (skb && (skb->skb_iif == dev->ifindex)) {
+ 			struct pppol2tp_common_addr info;
+ 
+-			if (ppp_is_multilink(dev) > 0) {
++			if (__ppp_is_multilink(dev) > 0) {
+ 				DEBUG_TRACE("%px: Net device: %px is MULTILINK PPP - Unknown to the ECM\n", feci, dev);
+ 				type_info.unknown.os_specific_ident = dev_interface_num;
+ 
+@@ -3658,7 +3658,7 @@ identifier_update:
+ 				ii = ecm_interface_unknown_interface_establish(&type_info.unknown, dev_name, dev_interface_num, ae_interface_num, dev_mtu);
+ 				return ii;
+ 			}
+-			channel_count = ppp_hold_channels(dev, ppp_chan, 1);
++			channel_count = __ppp_hold_channels(dev, ppp_chan, 1);
+ 			if (channel_count != 1) {
+ 				DEBUG_TRACE("%px: Net device: %px PPP has %d channels - ECM cannot handle this (interface becomes Unknown type)\n",
+ 					    feci, dev, channel_count);
+@@ -3764,7 +3764,7 @@ identifier_update:
+ 	/*
+ 	 * PPP - but what is the channel type?
+ 	 * First: If this is multi-link then we do not support it
+ 	 */
+-	if (ppp_is_multilink(dev) > 0) {
++	if (__ppp_is_multilink(dev) > 0) {
+ 		DEBUG_TRACE("%px: Net device: %px is MULTILINK PPP - Unknown to the ECM\n", feci, dev);
+ 		type_info.unknown.os_specific_ident = dev_interface_num;
+ 
+@@ -3780,7 +3780,7 @@ identifier_update:
+ 	 * Get the PPP channel and then enquire what kind of channel it is
+ 	 * NOTE: Not multilink so only one channel to get.
+ 	 */
+-	channel_count = ppp_hold_channels(dev, ppp_chan, 1);
++	channel_count = __ppp_hold_channels(dev, ppp_chan, 1);
+ 	if (channel_count != 1) {
+ 		DEBUG_TRACE("%px: Net device: %px PPP has %d channels - ECM cannot handle this (interface becomes Unknown type)\n",
+ 				feci, dev, channel_count);


### PR DESCRIPTION
Refactor PPP channel handling to use lockless functions.